### PR TITLE
Fix .pem file location in haproxy config

### DIFF
--- a/data/etc/haproxy/haproxy.cfg
+++ b/data/etc/haproxy/haproxy.cfg
@@ -40,7 +40,7 @@ defaults
 
 frontend tls
 	bind :80
-	bind :443 ssl crt /etc/haproxy/haproxychain.pem
+	bind :443 ssl crt /usr/local/etc/haproxy/haproxychain.pem
 
 	acl well path_beg /.well-known
 	use_backend nginx if well


### PR DESCRIPTION
The haproxy config file points to the incorrect path, causing the container to fail and restart.